### PR TITLE
Make API Compatible with Intersect Beta 8

### DIFF
--- a/src/Settings/Api.php
+++ b/src/Settings/Api.php
@@ -84,6 +84,12 @@ class Api
             return (curl_error($ch));
         }
 
+        $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        if ($httpcode == 401 || $httpcode == 403) {
+            $response = '{"Message": "Authorization has been denied for this request."}';
+        }
+
         $responseData = json_decode($response, true);
         curl_close($ch);
 
@@ -124,6 +130,12 @@ class Api
 
         if ($response === false) {
             return (curl_error($ch));
+        }
+
+        $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        if ($httpcode == 401 || $httpcode == 403) {
+            $response = '{"Message": "Authorization has been denied for this request."}';
         }
 
         $responseData = json_decode($response, true);


### PR DESCRIPTION
This will make CMS compatible with Intersect Beta 8.

The returned response text is different. Status codes are the preferred way to determine if reauthorization needs to happen.